### PR TITLE
Improve 3D camera controls and add presets

### DIFF
--- a/js/3d/core.mjs
+++ b/js/3d/core.mjs
@@ -72,7 +72,7 @@ export function getPostprocessing() {
 }
 
 // Editor-specific CSS for 3D viewport elements not covered by framework
-const STYLE_ID = "pixaroma-3d-extra-v1";
+const STYLE_ID = "pixaroma-3d-extra-v4";
 function injectExtraStyles() {
   if (document.getElementById(STYLE_ID)) return;
   // Remove ALL old 3D-specific style sheets
@@ -124,6 +124,10 @@ function injectExtraStyles() {
 .p3d-input{width:50px;background:#111;color:#e0e0e0;border:1px solid #3a3d40;border-radius:3px;padding:3px 4px;font-size:10px;font-family:monospace;text-align:center;}
 .p3d-btn{background:#1e2022;color:#ccc;border:1px solid #3a3d40;border-radius:4px;cursor:pointer;transition:all .12s;font-family:inherit;}
 .p3d-btn:hover{background:#2e3033;color:#f66744;border-color:#f66744;}
+.p3d-camera-disabled{opacity:.35;pointer-events:none;}
+.p3d-preset-row{display:grid;grid-template-columns:1fr auto auto auto;gap:4px;margin-top:6px;align-items:center;}
+.p3d-bg-preset-row{margin-bottom:20px;}
+.p3d-preset-select{min-width:0;background:#111;color:#e0e0e0;border:1px solid #3a3d40;border-radius:4px;padding:4px 5px;font-size:10px;}
 `;
   document.head.appendChild(s);
 }
@@ -187,6 +191,13 @@ export class Pixaroma3DEditor {
     this._fov = 50;
     this._shadows = true;
     this._isOrtho = false;
+    this._keyLock = false;
+    this._camLock = false;
+    this._fineMode = false;
+    this._orbitBaseSpeeds = null;
+    this.getSharedState = null;
+    this.setSharedState = null;
+    this._sharedPresetFallback = { camera_templates: [], background_templates: [] };
     this._groundMesh = null;
     this._showGrid = true;
     this._showGizmo = true;
@@ -347,6 +358,7 @@ export class Pixaroma3DEditor {
       }
       if (this.scene) this.scene.environment = null;
       window.removeEventListener("keydown", this._onKey, { capture: true });
+      window.removeEventListener("keyup", this._onKeyUp, { capture: true });
       if (this._resizeObs) this._resizeObs.disconnect();
       if (this._animId) {
         cancelAnimationFrame(this._animId);
@@ -691,6 +703,44 @@ export class Pixaroma3DEditor {
       uploadBtn.style.cssText = "width:100%;margin-bottom:6px;";
       pc.insertBefore(uploadBtn, bgFileInput.nextSibling);
 
+      const bgPresetRow = document.createElement("div");
+      bgPresetRow.className = "p3d-preset-row p3d-bg-preset-row";
+      bgPresetRow.style.marginBottom = "20px";
+      const bgPresetSelect = document.createElement("select");
+      bgPresetSelect.className = "p3d-preset-select";
+      const bgSaveBtn = createButton("Save", {
+        variant: "standard",
+        onClick: async (e) => {
+          e?.preventDefault?.();
+          e?.stopPropagation?.();
+          await this._saveBackgroundTemplate();
+        },
+        title: "Save current background image and settings as a workflow preset",
+      });
+      const bgApplyBtn = createButton("Apply", {
+        variant: "standard",
+        onClick: (e) => {
+          e?.preventDefault?.();
+          e?.stopPropagation?.();
+          this._applyBackgroundTemplate();
+        },
+        title: "Apply selected background preset",
+      });
+      const bgDeleteBtn = createButton("Delete", {
+        variant: "standard",
+        onClick: (e) => {
+          e?.preventDefault?.();
+          e?.stopPropagation?.();
+          this._deleteBackgroundTemplate();
+        },
+        title: "Delete selected background preset",
+      });
+      bgDeleteBtn.classList.add("pxf-btn-danger");
+      this.el.bgPresetSelect = bgPresetSelect;
+      bgPresetRow.append(bgPresetSelect, bgSaveBtn, bgApplyBtn, bgDeleteBtn);
+      pc.insertBefore(bgPresetRow, uploadBtn.nextSibling);
+      this._refreshBackgroundTemplateUI?.();
+
       // Sliders with consistent spacing
       const sliderGroup = document.createElement("div");
       sliderGroup.style.cssText = "margin-top:6px;display:flex;flex-direction:column;gap:2px;";
@@ -856,7 +906,9 @@ export class Pixaroma3DEditor {
       this.el.xformSliders.push({ label: lbl, slider, numIn, axis });
 
       const axLower = axis.toLowerCase();
+      this._wireFineSlider?.(slider, numIn);
       const apply = (v) => {
+        v = this._getFineSliderValue?.(slider, v) ?? v;
         if (!this.activeObj || this.activeObj.userData.locked) return;
         if (!dragState.snapshotted) {
           this._pushUndo();
@@ -1010,6 +1062,28 @@ export class Pixaroma3DEditor {
       cRow1.appendChild(b);
     });
     cam.content.appendChild(cRow1);
+    this.el.cameraViewButtons = [...cRow1.children];
+
+    const keyLockBtn = createButton("Key Lock", {
+      variant: "standard",
+      iconSrc: "/pixaroma/assets/icons/layers/lock-unlocked.svg",
+      onClick: () => this._setKeyLock(!this._keyLock),
+      title: "Lock numeric camera shortcuts (0–7, numpad, period focus)",
+    });
+    const camLockBtn = createButton("Cam Lock", {
+      variant: "standard",
+      iconSrc: "/pixaroma/assets/icons/layers/lock-unlocked.svg",
+      onClick: () => this._setCamLock(!this._camLock),
+      title: "Lock camera orbit, pan, zoom, view buttons, and camera shortcuts",
+    });
+    keyLockBtn.style.flex = "1";
+    camLockBtn.style.flex = "1";
+    this.el.keyLockBtn = keyLockBtn;
+    this.el.camLockBtn = camLockBtn;
+    const lockRow = createButtonRow([keyLockBtn, camLockBtn]);
+    lockRow.style.marginTop = "5px";
+    cam.content.appendChild(lockRow);
+
     const perspBtn = createButton("Perspective", {
       variant: "standard",
       onClick: () => {
@@ -1041,19 +1115,65 @@ export class Pixaroma3DEditor {
       title: "Center camera on selected object",
     });
     focusBtn.style.cssText = "width:100%;margin-top:5px;margin-bottom:8px;";
+    this.el.focusBtn = focusBtn;
     cam.content.appendChild(focusBtn);
     // FOV
+    let fovSliderEl = null;
     const fovR = createSliderRow("FOV", 15, 120, this._fov, (v) => {
+      v = this._getFineSliderValue?.(fovSliderEl, v) ?? v;
       this._fov = v;
       if (this.camera && this.camera.fov !== undefined) {
         this.camera.fov = v;
         this.camera.updateProjectionMatrix();
       }
     });
+    fovSliderEl = fovR.slider;
+    this._wireFineSlider?.(fovR.slider, fovR.numInput);
     this.el.fovSlider = fovR.slider;
     this.el.fovVal = fovR.numInput;
     this.el.fovRow = fovR.el;
     cam.content.appendChild(fovR.el);
+
+    const camPresetRow = document.createElement("div");
+    camPresetRow.className = "p3d-preset-row";
+    const camPresetSelect = document.createElement("select");
+    camPresetSelect.className = "p3d-preset-select";
+    const camSaveBtn = createButton("Save", {
+      variant: "standard",
+      onClick: (e) => {
+        e?.preventDefault?.();
+        e?.stopPropagation?.();
+        this._saveCameraTemplate();
+      },
+      title: "Save current camera view as a workflow preset",
+    });
+    const camApplyBtn = createButton("Apply", {
+      variant: "standard",
+      onClick: (e) => {
+        e?.preventDefault?.();
+        e?.stopPropagation?.();
+        this._applyCameraTemplate();
+      },
+      title: "Apply selected camera view preset",
+    });
+    const camDeleteBtn = createButton("Delete", {
+      variant: "standard",
+      onClick: (e) => {
+        e?.preventDefault?.();
+        e?.stopPropagation?.();
+        this._deleteCameraTemplate();
+      },
+      title: "Delete selected camera view preset",
+    });
+    camDeleteBtn.classList.add("pxf-btn-danger");
+    this.el.cameraPresetSelect = camPresetSelect;
+    camPresetRow.append(camPresetSelect, camSaveBtn, camApplyBtn, camDeleteBtn);
+    cam.content.appendChild(camPresetRow);
+    this._refreshCameraTemplateUI?.();
+
+    this._refreshLockButtons?.();
+    this._applyCamLockState?.();
+
     // Checkboxes
     const shCb = createCheckbox("Ground Shadows", this._shadows, (v) => {
       this._shadows = v;
@@ -1527,4 +1647,317 @@ Pixaroma3DEditor.prototype._updateAlignButtons = function () {
   for (const b of btns.distribute) {
     b.classList.toggle("disabled", !distribEnabled);
   }
+};
+
+
+// ─── Workflow Presets (Camera / Background) ─────────────────
+// Defined in core as well as persistence so the UI buttons are never left
+// without handlers if the browser serves a stale mixin module.
+Pixaroma3DEditor.prototype._presetState = function () {
+  let state = null;
+  try { state = this.getSharedState?.(); } catch {}
+  if (!state || typeof state !== "object") state = this._sharedPresetFallback;
+  if (!state || typeof state !== "object") state = {};
+  if (!Array.isArray(state.camera_templates)) state.camera_templates = [];
+  if (!Array.isArray(state.background_templates)) state.background_templates = [];
+  return state;
+};
+
+Pixaroma3DEditor.prototype._setPresetState = function (patch = {}) {
+  const prev = this._presetState();
+  const next = {
+    ...prev,
+    ...patch,
+    camera_templates: Array.isArray(patch.camera_templates)
+      ? patch.camera_templates
+      : (prev.camera_templates || []),
+    background_templates: Array.isArray(patch.background_templates)
+      ? patch.background_templates
+      : (prev.background_templates || []),
+  };
+  this._sharedPresetFallback = next;
+  try { this.setSharedState?.(next); } catch {}
+  this._refreshCameraTemplateUI?.();
+  this._refreshBackgroundTemplateUI?.();
+};
+
+Pixaroma3DEditor.prototype._syncPresetStateToSceneJson = function () {
+  if (this._isRestoring || !this.onSave || typeof this._serializeScene !== "function") return;
+  try {
+    const sd = this._serializeScene();
+    this.onSave(JSON.stringify(sd), null);
+  } catch (e) {
+    console.warn("[P3D] preset state sync failed", e);
+  }
+};
+
+Pixaroma3DEditor.prototype._makePresetId = function (prefix) {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+};
+
+Pixaroma3DEditor.prototype._nextTemplateName = function (base, templates) {
+  const names = new Set((templates || []).map((t) => String(t.name || "")));
+  let i = 1;
+  let name = `${base} ${i}`;
+  while (names.has(name)) {
+    i += 1;
+    name = `${base} ${i}`;
+  }
+  return name;
+};
+
+Pixaroma3DEditor.prototype._promptTemplateName = function (label, fallback) {
+  let name = fallback || "Preset";
+  try {
+    const entered = window.prompt(`${label} name`, name);
+    if (entered === null) return null;
+    name = String(entered).trim();
+  } catch {}
+  if (!name) {
+    this._setStatus?.(`${label} name missing`);
+    return null;
+  }
+  return name;
+};
+
+Pixaroma3DEditor.prototype._refreshTemplateSelect = function (select, templates, emptyLabel) {
+  if (!select) return;
+  const old = select.value;
+  select.innerHTML = "";
+  if (!templates.length) {
+    const opt = document.createElement("option");
+    opt.value = "";
+    opt.textContent = emptyLabel;
+    select.appendChild(opt);
+    return;
+  }
+  for (const t of templates) {
+    const opt = document.createElement("option");
+    opt.value = t.id;
+    opt.textContent = t.name || "Preset";
+    select.appendChild(opt);
+  }
+  if (templates.some((t) => t.id === old)) select.value = old;
+};
+
+Pixaroma3DEditor.prototype._refreshCameraTemplateUI = function () {
+  const templates = this._presetState().camera_templates || [];
+  this._refreshTemplateSelect(this.el.cameraPresetSelect, templates, "No views");
+};
+
+Pixaroma3DEditor.prototype._refreshBackgroundTemplateUI = function () {
+  const templates = this._presetState().background_templates || [];
+  this._refreshTemplateSelect(this.el.bgPresetSelect, templates, "No BG presets");
+};
+
+Pixaroma3DEditor.prototype._cameraSnapshot = function (name, id = null) {
+  if (!this.camera || !this.orbitCtrl) return null;
+  return {
+    id: id || this._makePresetId("cam"),
+    name,
+    position: {
+      x: this.camera.position.x,
+      y: this.camera.position.y,
+      z: this.camera.position.z,
+    },
+    target: {
+      x: this.orbitCtrl.target.x,
+      y: this.orbitCtrl.target.y,
+      z: this.orbitCtrl.target.z,
+    },
+    isOrtho: !!this._isOrtho,
+    fov: this._fov,
+    zoom: this.camera.zoom ?? 1,
+  };
+};
+
+Pixaroma3DEditor.prototype._saveCameraTemplate = function () {
+  const templates = [...(this._presetState().camera_templates || [])];
+  const fallback = this._nextTemplateName?.("View", templates) || `View ${templates.length + 1}`;
+  const name = this._promptTemplateName?.("Camera preset", fallback);
+  if (!name) return;
+  const existingIdx = templates.findIndex((t) => (t.name || "") === name);
+  const snap = this._cameraSnapshot(name, existingIdx >= 0 ? templates[existingIdx].id : null);
+  if (!snap) {
+    this._setStatus?.("Camera preset save failed");
+    return;
+  }
+  if (existingIdx >= 0) templates[existingIdx] = snap;
+  else templates.push(snap);
+  this._setPresetState({ camera_templates: templates });
+  if (this.el.cameraPresetSelect) this.el.cameraPresetSelect.value = snap.id;
+  this._syncPresetStateToSceneJson();
+  this._setStatus?.(existingIdx >= 0 ? "Camera preset updated" : "Camera preset saved");
+};
+
+Pixaroma3DEditor.prototype._selectedCameraTemplate = function () {
+  const id = this.el.cameraPresetSelect?.value;
+  return (this._presetState().camera_templates || []).find((t) => t.id === id) || null;
+};
+
+Pixaroma3DEditor.prototype._applyCameraTemplate = function () {
+  if (this._camLock) {
+    this._setStatus?.("Camera locked");
+    return;
+  }
+  const t = this._selectedCameraTemplate();
+  if (!t || !this.camera || !this.orbitCtrl) return;
+  this._setPerspective?.(!t.isOrtho, { force: true });
+  if (t.position) this.camera.position.set(t.position.x, t.position.y, t.position.z);
+  if (t.target) this.orbitCtrl.target.set(t.target.x, t.target.y, t.target.z);
+  if (t.fov !== undefined) {
+    this._fov = t.fov;
+    if (this.el.fovSlider) this.el.fovSlider.value = t.fov;
+    if (this.el.fovVal) this.el.fovVal.value = t.fov;
+    if (this.camera.fov !== undefined) this.camera.fov = t.fov;
+  }
+  if (t.zoom !== undefined && this.camera.zoom !== undefined) this.camera.zoom = t.zoom;
+  this.camera.lookAt(this.orbitCtrl.target);
+  this.camera.updateProjectionMatrix?.();
+  this.camera.updateMatrixWorld?.();
+  this.orbitCtrl.update();
+  this._setStatus?.("Camera preset applied");
+};
+
+Pixaroma3DEditor.prototype._deleteCameraTemplate = function () {
+  const id = this.el.cameraPresetSelect?.value;
+  if (!id) return;
+  const templates = (this._presetState().camera_templates || []).filter((t) => t.id !== id);
+  this._setPresetState({ camera_templates: templates });
+  this._syncPresetStateToSceneJson();
+  this._setStatus?.("Camera preset deleted");
+};
+
+Pixaroma3DEditor.prototype._bgTemplateSnapshot = function (name, path, id = null) {
+  return {
+    id: id || this._makePresetId("bg"),
+    name,
+    path,
+    x: this._bgImg.x || 0,
+    y: this._bgImg.y || 0,
+    scale: this._bgImg.scale || 100,
+    rotation: this._bgImg.rotation || 0,
+    opacity: this._bgImg.opacity ?? 100,
+    flipH: !!this._bgImg._flipH,
+    flipV: !!this._bgImg._flipV,
+  };
+};
+
+Pixaroma3DEditor.prototype._bgPathToSrc = function (path) {
+  if (!path) return null;
+  const parts = path.replace(/\\/g, "/").split("/");
+  const fname = parts.pop();
+  const subfolder = parts.join("/") || "pixaroma";
+  return "/view?filename=" +
+    encodeURIComponent(fname) +
+    "&type=input&subfolder=" +
+    encodeURIComponent(subfolder) +
+    "&t=" +
+    Date.now();
+};
+
+Pixaroma3DEditor.prototype._bgImageDataURL = async function () {
+  const img = this.el.bgImgEl;
+  if (!img?.src) return null;
+  if (img.src.startsWith("data:image")) return img.src;
+  try {
+    const res = await fetch(img.src, { cache: "no-store" });
+    if (res.ok) {
+      const blob = await res.blob();
+      return await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+      });
+    }
+  } catch {}
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth || this._bgImg._natW;
+    canvas.height = img.naturalHeight || this._bgImg._natH;
+    if (!canvas.width || !canvas.height) return null;
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(img, 0, 0);
+    return canvas.toDataURL("image/png");
+  } catch (e) {
+    console.warn("[P3D] background preset copy failed", e);
+    return null;
+  }
+};
+
+Pixaroma3DEditor.prototype._saveBackgroundTemplate = async function () {
+  if (!this.el.bgImgEl || !this._bgImg.path) {
+    this._setStatus?.("Background image missing");
+    return;
+  }
+  const templates = [...(this._presetState().background_templates || [])];
+  const fallback = this._nextTemplateName?.("Background", templates) || `Background ${templates.length + 1}`;
+  const name = this._promptTemplateName?.("Background preset", fallback);
+  if (!name) return;
+  this._setStatus?.("Saving background preset...");
+  const dataURL = await this._bgImageDataURL();
+  if (!dataURL) {
+    this._setStatus?.("Background image missing");
+    return;
+  }
+  const uploadId = `${this.projectId}_${this._makePresetId("bgpreset")}`.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  try {
+    const res = await ThreeDAPI.uploadBgImage(uploadId, dataURL);
+    if (res.status !== "success" || !res.path) {
+      this._setStatus?.("Background preset save failed");
+      return;
+    }
+    const existingIdx = templates.findIndex((t) => (t.name || "") === name);
+    const snap = this._bgTemplateSnapshot(name, res.path, existingIdx >= 0 ? templates[existingIdx].id : null);
+    if (existingIdx >= 0) templates[existingIdx] = snap;
+    else templates.push(snap);
+    this._setPresetState({ background_templates: templates });
+    if (this.el.bgPresetSelect) this.el.bgPresetSelect.value = snap.id;
+    this._syncPresetStateToSceneJson();
+    this._setStatus?.(existingIdx >= 0 ? "Background preset updated" : "Background preset saved");
+  } catch (e) {
+    console.warn("[P3D] bg preset upload", e);
+    this._setStatus?.("Background preset save error");
+  }
+};
+
+Pixaroma3DEditor.prototype._selectedBackgroundTemplate = function () {
+  const id = this.el.bgPresetSelect?.value;
+  return (this._presetState().background_templates || []).find((t) => t.id === id) || null;
+};
+
+Pixaroma3DEditor.prototype._applyBgTemplateState = function (t) {
+  if (!t?.path) return;
+  this._bgImg = {
+    path: t.path,
+    x: t.x || 0,
+    y: t.y || 0,
+    scale: t.scale || 100,
+    rotation: t.rotation || 0,
+    opacity: t.opacity ?? 100,
+    _flipH: !!t.flipH,
+    _flipV: !!t.flipV,
+    _natW: 0,
+    _natH: 0,
+  };
+  this._syncBgSliders?.();
+  const src = this._bgPathToSrc(t.path);
+  if (src) this._showBgImage?.(src, false);
+};
+
+Pixaroma3DEditor.prototype._applyBackgroundTemplate = function () {
+  const t = this._selectedBackgroundTemplate();
+  if (!t) return;
+  this._applyBgTemplateState(t);
+  this._setStatus?.("Background preset applied");
+};
+
+Pixaroma3DEditor.prototype._deleteBackgroundTemplate = function () {
+  const id = this.el.bgPresetSelect?.value;
+  if (!id) return;
+  const templates = (this._presetState().background_templates || []).filter((t) => t.id !== id);
+  this._setPresetState({ background_templates: templates });
+  this._syncPresetStateToSceneJson();
+  this._setStatus?.("Background preset deleted");
 };

--- a/js/3d/engine.mjs
+++ b/js/3d/engine.mjs
@@ -141,6 +141,13 @@ Pixaroma3DEditor.prototype._initThree = function () {
   this.orbitCtrl.enableDamping = true;
   this.orbitCtrl.dampingFactor = 0.08;
   this.orbitCtrl.target.set(0, 0.5, 0);
+  this._orbitBaseSpeeds = {
+    rotate: this.orbitCtrl.rotateSpeed ?? 1,
+    zoom: this.orbitCtrl.zoomSpeed ?? 1,
+    pan: this.orbitCtrl.panSpeed ?? 1,
+  };
+  this._applyOrbitFineMode?.();
+  this._applyCamLockState?.();
 
   this.transformCtrl = new TransformControls(
     this.camera,
@@ -149,7 +156,7 @@ Pixaroma3DEditor.prototype._initThree = function () {
   this.transformCtrl.setMode("translate");
   this.transformCtrl.setSize(0.85);
   this.transformCtrl.addEventListener("dragging-changed", (e) => {
-    this.orbitCtrl.enabled = !e.value;
+    this.orbitCtrl.enabled = !e.value && !this._camLock;
     this._gizmoDragging = e.value;
     // Show the custom gray drag indicator line during drag only.
     // Orient it along the axis currently being manipulated.
@@ -404,7 +411,9 @@ Pixaroma3DEditor.prototype._initThree = function () {
   });
 
   this._onKey = (e) => this._handleKey(e);
+  this._onKeyUp = (e) => this._handleKeyUp(e);
   window.addEventListener("keydown", this._onKey, { capture: true });
+  window.addEventListener("keyup", this._onKeyUp, { capture: true });
   this._resizeObs = new ResizeObserver(() => this._onResize());
   this._resizeObs.observe(vp);
   this._applyLightDir();

--- a/js/3d/index.js
+++ b/js/3d/index.js
@@ -13,6 +13,7 @@ import "./interaction.mjs";
 import "./persistence.mjs";
 import "./importer.mjs";
 
+
 import {
   allow_debug,
   createNodePreview,
@@ -21,6 +22,32 @@ import {
   activateNodePreview,
   downloadDataURL,
 } from "../shared/index.mjs";
+const PIXAROMA_3D_WORKFLOW_STATE_KEY = "pixaroma_3d_builder";
+
+function getWorkflow3DState() {
+  const graph = app.graph;
+  if (!graph) return { camera_templates: [], background_templates: [] };
+  if (!graph.extra || typeof graph.extra !== "object") graph.extra = {};
+  if (!graph.extra[PIXAROMA_3D_WORKFLOW_STATE_KEY] ||
+      typeof graph.extra[PIXAROMA_3D_WORKFLOW_STATE_KEY] !== "object") {
+    graph.extra[PIXAROMA_3D_WORKFLOW_STATE_KEY] = {};
+  }
+  const state = graph.extra[PIXAROMA_3D_WORKFLOW_STATE_KEY];
+  if (!Array.isArray(state.camera_templates)) state.camera_templates = [];
+  if (!Array.isArray(state.background_templates)) state.background_templates = [];
+  return state;
+}
+
+function setWorkflow3DState(next) {
+  const state = getWorkflow3DState();
+  state.camera_templates = Array.isArray(next?.camera_templates)
+    ? next.camera_templates
+    : state.camera_templates;
+  state.background_templates = Array.isArray(next?.background_templates)
+    ? next.background_templates
+    : state.background_templates;
+}
+
 
 app.registerExtension({
   name: "Pixaroma.3DEditor",
@@ -67,6 +94,11 @@ app.registerExtension({
     // ── Separate button widget ──
     node.addWidget("button", "Open 3D Builder", null, () => {
       const editor = new Pixaroma3DEditor();
+      editor.getSharedState = () => getWorkflow3DState();
+      editor.setSharedState = (next) => {
+        setWorkflow3DState(next);
+        node.setDirtyCanvas(true, true);
+      };
 
       // Apply default BG from ComfyUI settings (if user configured it).
       // ComfyUI's `color` setting type returns values without the leading

--- a/js/3d/interaction.mjs
+++ b/js/3d/interaction.mjs
@@ -30,7 +30,11 @@ Pixaroma3DEditor.prototype._setToolMode = function (mode) {
   this._updateTransformSliders?.();
 };
 
-Pixaroma3DEditor.prototype._camView = function (id) {
+Pixaroma3DEditor.prototype._camView = function (id, opts = {}) {
+  if (this._camLock && !opts.force) {
+    this._setStatus?.("Camera locked");
+    return;
+  }
   const dist = 6;
   // Orthographic-only zoom override — default is 1 (the camera's own
   // frustum bounds), but the iso view needs ~2× zoom so objects
@@ -102,7 +106,11 @@ Pixaroma3DEditor.prototype._camView = function (id) {
   this.orbitCtrl.update();
 };
 
-Pixaroma3DEditor.prototype._setPerspective = function (persp) {
+Pixaroma3DEditor.prototype._setPerspective = function (persp, opts = {}) {
+  if (this._camLock && !opts.force) {
+    this._setStatus?.("Camera locked");
+    return;
+  }
   const THREE = getTHREE();
   if (persp === !this._isOrtho) return; // Already in this mode
   const vp = this.el.viewport,
@@ -156,6 +164,98 @@ Pixaroma3DEditor.prototype._setPerspective = function (persp) {
   if (this.el.fovVal) this.el.fovVal.disabled = this._isOrtho;
 };
 
+
+Pixaroma3DEditor.prototype._setKeyLock = function (locked) {
+  this._keyLock = !!locked;
+  this._refreshLockButtons?.();
+};
+
+Pixaroma3DEditor.prototype._setCamLock = function (locked) {
+  this._camLock = !!locked;
+  this._refreshLockButtons?.();
+  this._applyCamLockState?.();
+};
+
+Pixaroma3DEditor.prototype._refreshLockButtons = function () {
+  const setBtn = (btn, locked) => {
+    if (!btn) return;
+    btn.classList.toggle("active", !!locked);
+    const img = btn.querySelector("img");
+    if (img) {
+      img.src = locked
+        ? "/pixaroma/assets/icons/layers/lock-locked.svg"
+        : "/pixaroma/assets/icons/layers/lock-unlocked.svg";
+    }
+  };
+  setBtn(this.el.keyLockBtn, this._keyLock);
+  setBtn(this.el.camLockBtn, this._camLock);
+};
+
+Pixaroma3DEditor.prototype._applyCamLockState = function () {
+  const locked = !!this._camLock;
+  if (this.orbitCtrl) {
+    this.orbitCtrl.enabled = !locked && !this._gizmoDragging;
+    this.orbitCtrl.enableRotate = !locked;
+    this.orbitCtrl.enablePan = !locked;
+    this.orbitCtrl.enableZoom = !locked;
+  }
+  const setDisabled = (el) => el?.classList?.toggle("p3d-camera-disabled", locked);
+  this.el.cameraViewButtons?.forEach(setDisabled);
+  setDisabled(this.el.perspBtn);
+  setDisabled(this.el.isoBtn);
+  setDisabled(this.el.focusBtn);
+};
+
+Pixaroma3DEditor.prototype._setFineMode = function (active) {
+  const next = !!active;
+  if (this._fineMode === next) return;
+  this._fineMode = next;
+  this._applyOrbitFineMode?.();
+};
+
+Pixaroma3DEditor.prototype._applyOrbitFineMode = function () {
+  if (!this.orbitCtrl || !this._orbitBaseSpeeds) return;
+  const f = this._fineMode ? 0.15 : 1;
+  this.orbitCtrl.rotateSpeed = this._orbitBaseSpeeds.rotate * f;
+  this.orbitCtrl.zoomSpeed = this._orbitBaseSpeeds.zoom * f;
+  this.orbitCtrl.panSpeed = this._orbitBaseSpeeds.pan * f;
+};
+
+Pixaroma3DEditor.prototype._wireFineSlider = function (slider, numInput) {
+  if (!slider || slider._p3dFineWired) return;
+  slider._p3dFineWired = true;
+  slider._p3dFineNumInput = numInput || null;
+  const start = () => {
+    slider._p3dFineDrag = {
+      raw: parseFloat(slider.value) || 0,
+      value: parseFloat(slider.value) || 0,
+    };
+  };
+  const end = () => {
+    slider._p3dFineDrag = null;
+  };
+  slider.addEventListener("pointerdown", start);
+  slider.addEventListener("mousedown", start);
+  slider.addEventListener("touchstart", start, { passive: true });
+  slider.addEventListener("pointerup", end);
+  slider.addEventListener("mouseup", end);
+  slider.addEventListener("touchend", end);
+  slider.addEventListener("change", end);
+};
+
+Pixaroma3DEditor.prototype._getFineSliderValue = function (slider, rawValue) {
+  const raw = parseFloat(rawValue);
+  if (!slider || !this._fineMode || !slider._p3dFineDrag || isNaN(raw)) return rawValue;
+  const st = slider._p3dFineDrag;
+  const v = st.value + (raw - st.raw) * 0.15;
+  slider.value = v;
+  if (slider._p3dFineNumInput) {
+    const formatted = this._formatXformValue ? this._formatXformValue(v) : String(v);
+    slider._p3dFineNumInput.value = formatted;
+  }
+  return v;
+};
+
 // ─── Interaction ──────────────────────────────────────────
 
 Pixaroma3DEditor.prototype._onClick = function (e) {
@@ -199,6 +299,15 @@ Pixaroma3DEditor.prototype._handleKey = function (e) {
   const k = e.key,
     kl = k.toLowerCase(),
     ctrl = e.ctrlKey || e.metaKey;
+  const isTypeableForSpace =
+    (tag === "INPUT" && ae?.type !== "range" &&
+     ae?.type !== "checkbox" && ae?.type !== "radio") ||
+    tag === "TEXTAREA" || tag === "SELECT";
+  if (e.code === "Space" && !isTypeableForSpace && !isTrap) {
+    e.preventDefault();
+    this._setFineMode(true);
+    return;
+  }
   if (ctrl && kl === "a") {
     e.preventDefault();
     // Blur any focused input first
@@ -315,13 +424,23 @@ Pixaroma3DEditor.prototype._handleKey = function (e) {
   if (kl === "m" || kl === "g") this._setToolMode("move");
   else if (kl === "r") this._setToolMode("rotate");
   else if (kl === "s") this._setToolMode("scale");
+  const isCameraShortcut = [
+    "Digit0", "Digit1", "Digit2", "Digit3", "Digit4", "Digit5", "Digit6", "Digit7",
+    "Numpad0", "Numpad1", "Numpad2", "Numpad3", "Numpad4", "Numpad5", "Numpad6", "Numpad7",
+    "Period", "NumpadDecimal",
+  ].includes(e.code);
+  if (isCameraShortcut && (this._keyLock || this._camLock)) {
+    e.preventDefault();
+    this._setStatus?.(this._camLock ? "Camera locked" : "Camera shortcuts locked");
+    return;
+  }
   // Camera shortcuts — use e.code so they work on every keyboard layout
   // (e.g. French AZERTY puts symbols on the number row in default mode;
   // e.key would be "&" "é" "\"" etc., but e.code stays "Digit1" "Digit2"…).
   //   1 Front · 2 Side (right) · 3 Back · 4 Top
   //   5 Perspective · 6 Isometric · 7 Other Side (left)
   //   0 Focus on selected
-  else if (e.code === "Digit1" || e.code === "Numpad1") this._camView("front");
+  if (e.code === "Digit1" || e.code === "Numpad1") this._camView("front");
   else if (e.code === "Digit2" || e.code === "Numpad2") this._camView("side");
   else if (e.code === "Digit3" || e.code === "Numpad3") this._camView("back");
   else if (e.code === "Digit4" || e.code === "Numpad4") this._camView("top");
@@ -342,6 +461,10 @@ Pixaroma3DEditor.prototype._handleKey = function (e) {
   else if (e.code === "Digit0" || e.code === "Numpad0") this._camView("focus");
   // Blender uses Numpad . (Period) to frame the active object — alias for 0.
   else if (e.code === "Period" || e.code === "NumpadDecimal") this._camView("focus");
+};
+
+Pixaroma3DEditor.prototype._handleKeyUp = function (e) {
+  if (e.code === "Space") this._setFineMode(false);
 };
 
 Pixaroma3DEditor.prototype._deselectAll = function () {

--- a/js/3d/persistence.mjs
+++ b/js/3d/persistence.mjs
@@ -22,6 +22,8 @@ Pixaroma3DEditor.prototype._serializeScene = function () {
     fov: this._fov,
     shadows: this._shadows,
     isOrtho: this._isOrtho,
+    key_lock: this._keyLock,
+    cam_lock: this._camLock,
     // Studio Lighting checkbox state — default ON if key is missing
     // on restore (preserves pre-v2 scene look).
     studioLighting: this._studioEnvOn !== false,
@@ -93,6 +95,7 @@ Pixaroma3DEditor.prototype._serializeScene = function () {
             y: this.orbitCtrl.target.y,
             z: this.orbitCtrl.target.z,
           },
+          zoom: this.camera.zoom ?? 1,
         }
       : null,
     light: {
@@ -111,8 +114,12 @@ Pixaroma3DEditor.prototype._serializeScene = function () {
           scale: this._bgImg.scale,
           rotation: this._bgImg.rotation,
           opacity: this._bgImg.opacity,
+          flipH: !!this._bgImg._flipH,
+          flipV: !!this._bgImg._flipV,
         }
       : null,
+    camera_templates: [...(this._presetState?.().camera_templates || [])],
+    background_templates: [...(this._presetState?.().background_templates || [])],
   };
 };
 
@@ -127,6 +134,17 @@ Pixaroma3DEditor.prototype._restoreScene = function (jsonStr) {
   this._isRestoring = true;
   try {
     const d = JSON.parse(jsonStr);
+    if (Array.isArray(d.camera_templates) || Array.isArray(d.background_templates)) {
+      const prevPresetState = this._presetState?.() || {};
+      this._setPresetState?.({
+        camera_templates: Array.isArray(prevPresetState.camera_templates) && prevPresetState.camera_templates.length
+          ? prevPresetState.camera_templates
+          : (Array.isArray(d.camera_templates) ? d.camera_templates : []),
+        background_templates: Array.isArray(prevPresetState.background_templates) && prevPresetState.background_templates.length
+          ? prevPresetState.background_templates
+          : (Array.isArray(d.background_templates) ? d.background_templates : []),
+      });
+    }
     if (d.doc_w) {
       this.docW = d.doc_w;
     }
@@ -156,7 +174,11 @@ Pixaroma3DEditor.prototype._restoreScene = function (jsonStr) {
       if (this.el.shadowCheck) this.el.shadowCheck.checked = d.shadows;
       if (this._groundMesh) this._groundMesh.visible = d.shadows;
     }
-    if (d.isOrtho) this._setPerspective(false);
+    if (d.isOrtho) this._setPerspective(false, { force: true });
+    if (d.key_lock !== undefined) this._keyLock = !!d.key_lock;
+    if (d.cam_lock !== undefined) this._camLock = !!d.cam_lock;
+    this._refreshLockButtons?.();
+    this._applyCamLockState?.();
     // Restore Studio Lighting state. If the saved scene predates this
     // field (v1), leave it ON (the default). If it's explicitly false,
     // drop the PMREM env off the scene so lighting matches what the
@@ -187,6 +209,10 @@ Pixaroma3DEditor.prototype._restoreScene = function (jsonStr) {
           d.camera.target.y,
           d.camera.target.z,
         );
+      if (d.camera.zoom !== undefined && this.camera.zoom !== undefined) {
+        this.camera.zoom = d.camera.zoom;
+        this.camera.updateProjectionMatrix?.();
+      }
       this.orbitCtrl.update();
     }
     if (d.light) {
@@ -243,6 +269,8 @@ Pixaroma3DEditor.prototype._restoreScene = function (jsonStr) {
         scale: d.bgImage.scale || 100,
         rotation: d.bgImage.rotation || 0,
         opacity: d.bgImage.opacity ?? 100,
+        _flipH: !!d.bgImage.flipH,
+        _flipV: !!d.bgImage.flipV,
         _natW: 0,
         _natH: 0,
       };
@@ -728,6 +756,7 @@ Pixaroma3DEditor.prototype._close = function () {
   if (this._animId) cancelAnimationFrame(this._animId);
   this._animId = null;
   window.removeEventListener("keydown", this._onKey, { capture: true });
+  window.removeEventListener("keyup", this._onKeyUp, { capture: true });
   if (this._resizeObs) this._resizeObs.disconnect();
   if (this.transformCtrl) {
     this.transformCtrl.detach();
@@ -756,6 +785,313 @@ Pixaroma3DEditor.prototype._close = function () {
   this.camera = null;
   this.renderer = null;
   if (this.onClose) this.onClose();
+};
+
+
+// ─── Workflow Presets (Camera / Background) ─────────────────
+
+Pixaroma3DEditor.prototype._presetState = function () {
+  let state = null;
+  try { state = this.getSharedState?.(); } catch {}
+  if (!state || typeof state !== "object") state = this._sharedPresetFallback;
+  if (!Array.isArray(state.camera_templates)) state.camera_templates = [];
+  if (!Array.isArray(state.background_templates)) state.background_templates = [];
+  return state;
+};
+
+Pixaroma3DEditor.prototype._setPresetState = function (patch) {
+  const prev = this._presetState();
+  const next = {
+    ...prev,
+    ...patch,
+    camera_templates: patch.camera_templates || prev.camera_templates || [],
+    background_templates: patch.background_templates || prev.background_templates || [],
+  };
+  this._sharedPresetFallback = next;
+  try { this.setSharedState?.(next); } catch {}
+  this._refreshCameraTemplateUI?.();
+  this._refreshBackgroundTemplateUI?.();
+};
+
+Pixaroma3DEditor.prototype._syncPresetStateToSceneJson = function () {
+  if (this._isRestoring || !this.onSave) return;
+  try {
+    const sd = this._serializeScene();
+    this.onSave(JSON.stringify(sd), null);
+  } catch (e) {
+    console.warn("[P3D] preset state sync failed", e);
+  }
+};
+
+Pixaroma3DEditor.prototype._makePresetId = function (prefix) {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+};
+
+Pixaroma3DEditor.prototype._nextTemplateName = function (base, templates) {
+  const names = new Set((templates || []).map((t) => String(t.name || "")));
+  let i = 1;
+  let name = `${base} ${i}`;
+  while (names.has(name)) {
+    i += 1;
+    name = `${base} ${i}`;
+  }
+  return name;
+};
+
+Pixaroma3DEditor.prototype._promptTemplateName = function (label, fallback) {
+  let name = fallback || "Preset";
+  try {
+    const entered = window.prompt(`${label} name`, name);
+    if (entered === null) return null;
+    name = String(entered).trim();
+  } catch {}
+  if (!name) {
+    this._setStatus?.(`${label} name missing`);
+    return null;
+  }
+  return name;
+};
+
+Pixaroma3DEditor.prototype._refreshTemplateSelect = function (select, templates, emptyLabel) {
+  if (!select) return;
+  const old = select.value;
+  select.innerHTML = "";
+  if (!templates.length) {
+    const opt = document.createElement("option");
+    opt.value = "";
+    opt.textContent = emptyLabel;
+    select.appendChild(opt);
+    return;
+  }
+  for (const t of templates) {
+    const opt = document.createElement("option");
+    opt.value = t.id;
+    opt.textContent = t.name || "Preset";
+    select.appendChild(opt);
+  }
+  if (templates.some((t) => t.id === old)) select.value = old;
+};
+
+Pixaroma3DEditor.prototype._refreshCameraTemplateUI = function () {
+  const templates = this._presetState().camera_templates || [];
+  this._refreshTemplateSelect(this.el.cameraPresetSelect, templates, "No views");
+};
+
+Pixaroma3DEditor.prototype._refreshBackgroundTemplateUI = function () {
+  const templates = this._presetState().background_templates || [];
+  this._refreshTemplateSelect(this.el.bgPresetSelect, templates, "No BG presets");
+};
+
+Pixaroma3DEditor.prototype._cameraSnapshot = function (name, id = null) {
+  if (!this.camera || !this.orbitCtrl) return null;
+  return {
+    id: id || this._makePresetId("cam"),
+    name,
+    position: {
+      x: this.camera.position.x,
+      y: this.camera.position.y,
+      z: this.camera.position.z,
+    },
+    target: {
+      x: this.orbitCtrl.target.x,
+      y: this.orbitCtrl.target.y,
+      z: this.orbitCtrl.target.z,
+    },
+    isOrtho: !!this._isOrtho,
+    fov: this._fov,
+    zoom: this.camera.zoom ?? 1,
+  };
+};
+
+Pixaroma3DEditor.prototype._saveCameraTemplate = function () {
+  const templates = [...(this._presetState().camera_templates || [])];
+  const fallback = this._nextTemplateName?.("View", templates) || `View ${templates.length + 1}`;
+  const name = this._promptTemplateName?.("Camera preset", fallback);
+  if (!name) return;
+  const existingIdx = templates.findIndex((t) => (t.name || "") === name);
+  const snap = this._cameraSnapshot(name, existingIdx >= 0 ? templates[existingIdx].id : null);
+  if (!snap) {
+    this._setStatus?.("Camera preset save failed");
+    return;
+  }
+  if (existingIdx >= 0) templates[existingIdx] = snap;
+  else templates.push(snap);
+  this._setPresetState({ camera_templates: templates });
+  if (this.el.cameraPresetSelect) this.el.cameraPresetSelect.value = snap.id;
+  this._syncPresetStateToSceneJson();
+  this._setStatus?.(existingIdx >= 0 ? "Camera preset updated" : "Camera preset saved");
+};
+
+Pixaroma3DEditor.prototype._selectedCameraTemplate = function () {
+  const id = this.el.cameraPresetSelect?.value;
+  return (this._presetState().camera_templates || []).find((t) => t.id === id) || null;
+};
+
+Pixaroma3DEditor.prototype._applyCameraTemplate = function () {
+  if (this._camLock) {
+    this._setStatus?.("Camera locked");
+    return;
+  }
+  const t = this._selectedCameraTemplate();
+  if (!t) return;
+  this._setPerspective(!t.isOrtho);
+  if (t.position) this.camera.position.set(t.position.x, t.position.y, t.position.z);
+  if (t.target) this.orbitCtrl.target.set(t.target.x, t.target.y, t.target.z);
+  if (t.fov !== undefined) {
+    this._fov = t.fov;
+    if (this.el.fovSlider) this.el.fovSlider.value = t.fov;
+    if (this.el.fovVal) this.el.fovVal.value = t.fov;
+    if (this.camera.fov !== undefined) this.camera.fov = t.fov;
+  }
+  if (t.zoom !== undefined && this.camera.zoom !== undefined) this.camera.zoom = t.zoom;
+  this.camera.lookAt(this.orbitCtrl.target);
+  this.camera.updateProjectionMatrix?.();
+  this.camera.updateMatrixWorld?.();
+  this.orbitCtrl.update();
+  this._setStatus?.("Camera preset applied");
+};
+
+Pixaroma3DEditor.prototype._deleteCameraTemplate = function () {
+  const id = this.el.cameraPresetSelect?.value;
+  if (!id) return;
+  const templates = (this._presetState().camera_templates || []).filter((t) => t.id !== id);
+  this._setPresetState({ camera_templates: templates });
+  this._syncPresetStateToSceneJson();
+  this._setStatus?.("Camera preset deleted");
+};
+
+Pixaroma3DEditor.prototype._bgTemplateSnapshot = function (name, path, id = null) {
+  return {
+    id: id || this._makePresetId("bg"),
+    name,
+    path,
+    x: this._bgImg.x || 0,
+    y: this._bgImg.y || 0,
+    scale: this._bgImg.scale || 100,
+    rotation: this._bgImg.rotation || 0,
+    opacity: this._bgImg.opacity ?? 100,
+    flipH: !!this._bgImg._flipH,
+    flipV: !!this._bgImg._flipV,
+  };
+};
+
+Pixaroma3DEditor.prototype._bgPathToSrc = function (path) {
+  if (!path) return null;
+  const parts = path.replace(/\\/g, "/").split("/");
+  const fname = parts.pop();
+  const subfolder = parts.join("/") || "pixaroma";
+  return "/view?filename=" +
+    encodeURIComponent(fname) +
+    "&type=input&subfolder=" +
+    encodeURIComponent(subfolder) +
+    "&t=" +
+    Date.now();
+};
+
+Pixaroma3DEditor.prototype._bgImageDataURL = async function () {
+  const img = this.el.bgImgEl;
+  if (!img?.src) return null;
+  if (img.src.startsWith("data:image")) return img.src;
+  try {
+    const res = await fetch(img.src, { cache: "no-store" });
+    if (res.ok) {
+      const blob = await res.blob();
+      return await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+      });
+    }
+  } catch {}
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth || this._bgImg._natW;
+    canvas.height = img.naturalHeight || this._bgImg._natH;
+    if (!canvas.width || !canvas.height) return null;
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(img, 0, 0);
+    return canvas.toDataURL("image/png");
+  } catch (e) {
+    console.warn("[P3D] background preset copy failed", e);
+    return null;
+  }
+};
+
+Pixaroma3DEditor.prototype._saveBackgroundTemplate = async function () {
+  if (!this.el.bgImgEl || !this._bgImg.path) {
+    this._setStatus?.("Background image missing");
+    return;
+  }
+  const templates = [...(this._presetState().background_templates || [])];
+  const fallback = this._nextTemplateName?.("Background", templates) || `Background ${templates.length + 1}`;
+  const name = this._promptTemplateName?.("Background preset", fallback);
+  if (!name) return;
+  this._setStatus?.("Saving background preset...");
+  const dataURL = await this._bgImageDataURL();
+  if (!dataURL) {
+    this._setStatus?.("Background image missing");
+    return;
+  }
+  const uploadId = `${this.projectId}_${this._makePresetId("bgpreset")}`.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  try {
+    const res = await ThreeDAPI.uploadBgImage(uploadId, dataURL);
+    if (res.status !== "success" || !res.path) {
+      this._setStatus?.("Background preset save failed");
+      return;
+    }
+    const existingIdx = templates.findIndex((t) => (t.name || "") === name);
+    const snap = this._bgTemplateSnapshot(name, res.path, existingIdx >= 0 ? templates[existingIdx].id : null);
+    if (existingIdx >= 0) templates[existingIdx] = snap;
+    else templates.push(snap);
+    this._setPresetState({ background_templates: templates });
+    if (this.el.bgPresetSelect) this.el.bgPresetSelect.value = snap.id;
+    this._syncPresetStateToSceneJson();
+    this._setStatus?.(existingIdx >= 0 ? "Background preset updated" : "Background preset saved");
+  } catch (e) {
+    console.warn("[P3D] bg preset upload", e);
+    this._setStatus?.("Background preset save error");
+  }
+};
+
+Pixaroma3DEditor.prototype._selectedBackgroundTemplate = function () {
+  const id = this.el.bgPresetSelect?.value;
+  return (this._presetState().background_templates || []).find((t) => t.id === id) || null;
+};
+
+Pixaroma3DEditor.prototype._applyBgTemplateState = function (t) {
+  if (!t?.path) return;
+  this._bgImg = {
+    path: t.path,
+    x: t.x || 0,
+    y: t.y || 0,
+    scale: t.scale || 100,
+    rotation: t.rotation || 0,
+    opacity: t.opacity ?? 100,
+    _flipH: !!t.flipH,
+    _flipV: !!t.flipV,
+    _natW: 0,
+    _natH: 0,
+  };
+  this._syncBgSliders();
+  const src = this._bgPathToSrc(t.path);
+  if (src) this._showBgImage(src, false);
+};
+
+Pixaroma3DEditor.prototype._applyBackgroundTemplate = function () {
+  const t = this._selectedBackgroundTemplate();
+  if (!t) return;
+  this._applyBgTemplateState(t);
+  this._setStatus?.("Background preset applied");
+};
+
+Pixaroma3DEditor.prototype._deleteBackgroundTemplate = function () {
+  const id = this.el.bgPresetSelect?.value;
+  if (!id) return;
+  const templates = (this._presetState().background_templates || []).filter((t) => t.id !== id);
+  this._setPresetState({ background_templates: templates });
+  this._syncPresetStateToSceneJson();
+  this._setStatus?.("Background preset deleted");
 };
 
 // ─── Background Image (CSS 2D) ─────────────────────────────


### PR DESCRIPTION
## Summary

This PR adds several workflow improvements to the 3D Builder node while keeping the existing 3D layer logic and backend routes unchanged.

## Added

### Camera presets

- Added Save / Apply / Delete controls for camera views.
- Presets store camera position, orbit target, perspective/orthographic mode, FOV, zoom, and preset name.
- Presets are saved in the workflow/state, not in localStorage.
- Presets are available to all 3D Builder nodes within the same workflow.
- Saving with an existing name updates the preset instead of creating a duplicate.

### Background presets

- Added Save / Apply / Delete controls for background images.
- Presets store the background image path and existing background settings.
- Presets are saved in the workflow/state.
- Background image saving uses the existing `/pixaroma/api/3d/bg_upload` mechanism.
- Backend routes were not rewritten.

### Key Lock

- Added a Key Lock button with the existing lock/unlock icon.
- Blocks camera hotkeys:
  - Digit0–Digit7
  - Numpad0–Numpad7
  - Period
  - NumpadDecimal
- Input fields are not affected.

### Cam Lock

- Added a Cam Lock button with the existing lock/unlock icon.
- Blocks camera orbit, pan, zoom, view buttons, perspective/isometric switching, focus selected, and camera keyboard shortcuts.
- Object editing remains available.

### Space Fine Mode

- Holding Space temporarily reduces sensitivity to 15%.
- Applies to camera movement, FOV/perspective slider, and Position/Rotation/Scale sliders.
- TransformControls / viewport gizmo was intentionally left unchanged.

## Modified files

- `js/3d/core.mjs`
- `js/3d/interaction.mjs`
- `js/3d/engine.mjs`
- `js/3d/persistence.mjs`
- `js/3d/index.js`